### PR TITLE
allow downloads in iframe sandbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metal-heaven/rh24-webapp-sdk",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Rh24 webapp integration library",
   "files": [
     "dist/**/*"

--- a/src/__tests__/rh24-webapp-sdk.test.ts
+++ b/src/__tests__/rh24-webapp-sdk.test.ts
@@ -40,14 +40,14 @@ test('after call render, the iframe should be visible with the right sandbox', (
   const iframe = renderRhodium('app', '/projects')
 
   expect(iframe).not.toBeNull()
-  expect(iframe.sandbox).toBe('allow-top-navigation allow-scripts allow-same-origin allow-forms allow-modals')
+  expect(iframe.sandbox).toBe('allow-top-navigation allow-scripts allow-same-origin allow-forms allow-modals allow-top-navigation-by-user-activation') 
 })
 
 test('should render at body tag if rootElementId is null', () => {
   const iframe = renderRhodium()
 
   expect(iframe).not.toBeNull()
-  expect(iframe.sandbox).toBe('allow-top-navigation allow-scripts allow-same-origin allow-forms allow-modals')
+  expect(iframe.sandbox).toBe('allow-top-navigation allow-scripts allow-same-origin allow-forms allow-modals allow-top-navigation-by-user-activation')
 })
 
 test('should append random v parameter with & if other query strings are present', () => {

--- a/src/__tests__/rh24-webapp-sdk.test.ts
+++ b/src/__tests__/rh24-webapp-sdk.test.ts
@@ -40,14 +40,18 @@ test('after call render, the iframe should be visible with the right sandbox', (
   const iframe = renderRhodium('app', '/projects')
 
   expect(iframe).not.toBeNull()
-  expect(iframe.sandbox).toBe('allow-top-navigation allow-scripts allow-same-origin allow-forms allow-modals allow-top-navigation-by-user-activation') 
+  expect(iframe.sandbox).toBe(
+    'allow-top-navigation allow-scripts allow-same-origin allow-forms allow-modals allow-top-navigation-by-user-activation allow-downloads'
+  )
 })
 
 test('should render at body tag if rootElementId is null', () => {
   const iframe = renderRhodium()
 
   expect(iframe).not.toBeNull()
-  expect(iframe.sandbox).toBe('allow-top-navigation allow-scripts allow-same-origin allow-forms allow-modals allow-top-navigation-by-user-activation')
+  expect(iframe.sandbox).toBe(
+    'allow-top-navigation allow-scripts allow-same-origin allow-forms allow-modals allow-top-navigation-by-user-activation allow-downloads'
+  )
 })
 
 test('should append random v parameter with & if other query strings are present', () => {

--- a/src/rh24-webapp-sdk.ts
+++ b/src/rh24-webapp-sdk.ts
@@ -15,6 +15,10 @@ export class Rh24WebApp {
       throw new Error('[rh24-embedded] partyId should not be null or empty')
     }
 
+    if (!this._config.rh24BaseUrl) {
+      throw new Error('[rh24-embedded] rh24BaseUrl should not be null or empty')
+    }
+
     let element
 
     if (rootElementId) {
@@ -31,8 +35,9 @@ export class Rh24WebApp {
 
     const iframe = document.createElement('iframe')
 
-    let iframeSrc = `${this._config.rh24BaseUrl.replace(/\'/g, '')}/app/${relativePath.startsWith('/') ? relativePath.slice(1) : relativePath
-      }`
+    let iframeSrc = `${this._config.rh24BaseUrl.replace(/\'/g, '')}/app/${
+      relativePath.startsWith('/') ? relativePath.slice(1) : relativePath
+    }`
 
     if (this._config.options?.disableCache) {
       iframeSrc += `${iframeSrc.indexOf('?') > -1 ? '&' : '?'}v=${Math.random()}`
@@ -47,7 +52,8 @@ export class Rh24WebApp {
     iframe.setAttribute('data-testid', 'rh24-iframe')
 
     // @ts-ignore
-    iframe.sandbox = 'allow-top-navigation allow-scripts allow-same-origin allow-forms allow-modals'
+    iframe.sandbox =
+      'allow-top-navigation allow-scripts allow-same-origin allow-forms allow-modals allow-top-navigation-by-user-activation'
 
     element.style.overflowY = 'hidden'
 

--- a/src/rh24-webapp-sdk.ts
+++ b/src/rh24-webapp-sdk.ts
@@ -53,7 +53,7 @@ export class Rh24WebApp {
 
     // @ts-ignore
     iframe.sandbox =
-      'allow-top-navigation allow-scripts allow-same-origin allow-forms allow-modals allow-top-navigation-by-user-activation'
+      'allow-top-navigation allow-scripts allow-same-origin allow-forms allow-modals allow-top-navigation-by-user-activation allow-downloads'
 
     element.style.overflowY = 'hidden'
 


### PR DESCRIPTION
the system should not open a new browser tab when user asks for the quotation document in the portal view. For that the allow-downloads string should be present in the iframe sandbox where rh24 runs